### PR TITLE
Fixed leak of a CFString

### DIFF
--- a/DCTextEngine.m
+++ b/DCTextEngine.m
@@ -211,7 +211,7 @@
 {
     CTFontRef font = CTFontCreateWithName((__bridge CFStringRef)self.font.fontName, self.font.pointSize, NULL);
     CTFontRef newFont = CTFontCreateCopyWithSymbolicTraits(font, 0.0, NULL, trait, trait);
-    NSString *fontName = (__bridge NSString *)CTFontCopyName(newFont, kCTFontPostScriptNameKey);
+    NSString *fontName = (__bridge_transfer NSString *)CTFontCopyName(newFont, kCTFontPostScriptNameKey);
     CFRelease(font);
     CFRelease(newFont);
     


### PR DESCRIPTION
The CFString holding the name of the font has a retain count of 1 (since it is returned by a method with the word "Copy" in its name). 

It was bridged to an NSString (using `__bridge`) without transferring ownership to ARC. Using `__bridge_transfer` will transfer the ownership to ARC and the string will be correctly memory managed.

Further verification: The leak is flagged if you run the Xcode 7 static analyzer, and the analyzer issue is resolved by applying the change contained in this pull request.