### PR TITLE
Unordered list indentation

### DIFF
--- a/DCTextEngine.h
+++ b/DCTextEngine.h
@@ -161,7 +161,7 @@ typedef DCTextOptions* (^DCTextEngineDetector)(NSTextCheckingResult *result, NSS
  @param text: the text that was found.
  @return DCTextOptions with unorder list replace text.
  */
-+(DCTextOptions*)unorderList:(NSString*)replace text:(NSString*)text;
+-(DCTextOptions*)unorderList:(NSString*)replace text:(NSString*)text;
 
 /**
  @return returns a suggestedHeight, based on the attributedString.


### PR DESCRIPTION
Refactored unordered list indentation to use NSMutableParagraphStyle's headIndent property to get flush left margin and proper line breaking for long list items. 

Incidental changes:
- List matching regex to match entire line.
- unorderList:text: has been made an instance method to get access to self.font and similar properties.

Note: This change will style all unordered lists in the manner of regular body text. This might be undesirable? If so, please advise.
